### PR TITLE
fix: correct meta spread order in forEachOpenApiProcedure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dokploy/trpc-openapi",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "tRPC OpenAPI",
   "author": "dokploy",
   "private": false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,8 +30,10 @@ export type OpenApiMeta<TMeta = TRPCMeta> = TMeta & {
     /** When true, merge provided openapi with defaults (defaults first, then provided). */
     additional?: boolean;
     enabled?: boolean;
-    method: OpenApiMethod;
-    path: `/${string}`;
+    /** HTTP method. Auto-generated from procedure type (query→GET, mutation→POST) when omitted. */
+    method?: OpenApiMethod;
+    /** URL path. Auto-generated as /{routerName}.{procedureName} when omitted. */
+    path?: `/${string}`;
     operationId?: string;
     summary?: string;
     description?: string;
@@ -45,6 +47,13 @@ export type OpenApiMeta<TMeta = TRPCMeta> = TMeta & {
     errorResponses?: number[] | Record<number, string>;
   };
 };
+
+/**
+ * Internal resolved type where method and path are guaranteed after merging with defaults.
+ * Used internally after forEachOpenApiProcedure resolves auto-generated defaults.
+ */
+export type ResolvedOpenApiMeta = Required<Pick<NonNullable<OpenApiMeta['openapi']>, 'method' | 'path'>> &
+  NonNullable<OpenApiMeta['openapi']>;
 
 export type OpenApiProcedure = Procedure<
   ProcedureType,

--- a/src/utils/procedure.ts
+++ b/src/utils/procedure.ts
@@ -83,7 +83,7 @@ export const forEachOpenApiProcedure = <TMeta = Record<string, unknown>>(
     } else if (additional && meta?.openapi) {
       openapi = { ...defaultOpenApiMeta, ...meta.openapi };
     } else if (meta?.openapi) {
-      openapi = { ...meta.openapi, ...defaultOpenApiMeta };
+      openapi = { ...defaultOpenApiMeta, ...meta.openapi };
     } else {
       openapi = defaultOpenApiMeta;
     }
@@ -94,8 +94,8 @@ export const forEachOpenApiProcedure = <TMeta = Record<string, unknown>>(
         type,
         procedure: procedure as OpenApiProcedure,
         meta: {
-          openapi,
           ...(meta as TMeta),
+          openapi,
         },
       });
     }

--- a/src/utils/procedure.ts
+++ b/src/utils/procedure.ts
@@ -1,7 +1,7 @@
 import { TRPCProcedureType } from '@trpc/server';
 import { ZodObject, z } from 'zod';
 
-import { OpenApiMeta, OpenApiMethod, OpenApiProcedure, OpenApiProcedureRecord } from '../types';
+import { OpenApiMeta, OpenApiMethod, OpenApiProcedure, OpenApiProcedureRecord, ResolvedOpenApiMeta } from '../types';
 
 const mergeInputs = (inputParsers: ZodObject[]): ZodObject => {
   return inputParsers.reduce((acc, inputParser) => {
@@ -55,7 +55,7 @@ export const forEachOpenApiProcedure = <TMeta = Record<string, unknown>>(
     type: TRPCProcedureType;
     procedure: OpenApiProcedure;
     meta: {
-      openapi: NonNullable<OpenApiMeta['openapi']>;
+      openapi: ResolvedOpenApiMeta;
     } & TMeta;
   }) => void,
 ) => {
@@ -68,7 +68,7 @@ export const forEachOpenApiProcedure = <TMeta = Record<string, unknown>>(
     const additional = meta?.openapi?.additional ?? false;
     const override = meta?.openapi?.override ?? false;
 
-    const defaultOpenApiMeta: NonNullable<OpenApiMeta['openapi']> = {
+    const defaultOpenApiMeta: ResolvedOpenApiMeta = {
       method: getMethod(procedure as OpenApiProcedure),
       path: `/${path}`,
       enabled: true,
@@ -76,10 +76,10 @@ export const forEachOpenApiProcedure = <TMeta = Record<string, unknown>>(
       protect: true,
     };
 
-    let openapi: NonNullable<OpenApiMeta['openapi']>;
+    let openapi: ResolvedOpenApiMeta;
 
     if (override && meta?.openapi) {
-      openapi = { ...meta.openapi };
+      openapi = { ...meta.openapi } as ResolvedOpenApiMeta;
     } else if (additional && meta?.openapi) {
       openapi = { ...defaultOpenApiMeta, ...meta.openapi };
     } else if (meta?.openapi) {

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -753,7 +753,9 @@ describe('generator', () => {
                 },
               ],
               "summary": undefined,
-              "tags": undefined,
+              "tags": Array [
+                "readUsers",
+              ],
             },
             "post": Object {
               "description": undefined,
@@ -848,7 +850,9 @@ describe('generator', () => {
                 },
               ],
               "summary": undefined,
-              "tags": undefined,
+              "tags": Array [
+                "createUser",
+              ],
             },
           },
           "/users/{id}": Object {
@@ -931,7 +935,9 @@ describe('generator', () => {
                 },
               ],
               "summary": undefined,
-              "tags": undefined,
+              "tags": Array [
+                "deleteUser",
+              ],
             },
             "get": Object {
               "description": undefined,
@@ -1027,7 +1033,9 @@ describe('generator', () => {
                 },
               ],
               "summary": undefined,
-              "tags": undefined,
+              "tags": Array [
+                "readUser",
+              ],
             },
             "patch": Object {
               "description": undefined,
@@ -1138,7 +1146,9 @@ describe('generator', () => {
                 },
               ],
               "summary": undefined,
-              "tags": undefined,
+              "tags": Array [
+                "updateUser",
+              ],
             },
           },
         },
@@ -1367,7 +1377,9 @@ describe('generator', () => {
           },
         ],
         "summary": undefined,
-        "tags": undefined,
+        "tags": Array [
+          "createUser",
+        ],
       }
     `);
     expect(openApiDocument.paths!['/user']!.get!).toMatchInlineSnapshot(`
@@ -1474,7 +1486,9 @@ describe('generator', () => {
           },
         ],
         "summary": undefined,
-        "tags": undefined,
+        "tags": Array [
+          "getUser",
+        ],
       }
     `);
   });
@@ -1856,7 +1870,11 @@ describe('generator', () => {
     const serverIdParam = params.find((p) => p.name === 'serverId');
     expect(containerIdParam).toBeDefined();
     expect(containerIdParam!.required).toBe(true);
-    expect(containerIdParam!.schema).toMatchObject({ type: 'string', minLength: 1, pattern: containerIdRegex.source });
+    expect(containerIdParam!.schema).toMatchObject({
+      type: 'string',
+      minLength: 1,
+      pattern: containerIdRegex.source,
+    });
     expect(serverIdParam).toBeDefined();
     expect(serverIdParam!.required).not.toBe(true);
   });
@@ -2792,7 +2810,9 @@ describe('generator', () => {
               },
             ],
             "summary": undefined,
-            "tags": undefined,
+            "tags": Array [
+              "procedure",
+            ],
           },
         },
         "/router/procedure": Object {
@@ -2886,7 +2906,9 @@ describe('generator', () => {
               },
             ],
             "summary": undefined,
-            "tags": undefined,
+            "tags": Array [
+              "router",
+            ],
           },
         },
         "/router/router/procedure": Object {
@@ -2980,7 +3002,9 @@ describe('generator', () => {
               },
             ],
             "summary": undefined,
-            "tags": undefined,
+            "tags": Array [
+              "router",
+            ],
           },
         },
       }
@@ -3118,7 +3142,7 @@ describe('generator', () => {
         (openApiDocument.paths!['/with-all']!.post!.requestBody as any).content['application/json'],
       ).toEqual(
         (openApiDocument.paths!['/with-all']!.post!.requestBody as any).content[
-        'application/x-www-form-urlencoded'
+          'application/x-www-form-urlencoded'
         ],
       );
       expect(
@@ -3610,9 +3634,8 @@ describe('generator', () => {
 
       const openApiDocument = generateOpenApiDocument(appRouter, defaultDocOpts);
 
-      const schema = (openApiDocument.paths!['/upload-multiple']?.post?.requestBody as any)?.content[
-        'multipart/form-data'
-      ]?.schema;
+      const schema = (openApiDocument.paths!['/upload-multiple']?.post?.requestBody as any)
+        ?.content['multipart/form-data']?.schema;
 
       expect(schema.properties.document).toEqual({ type: 'string', format: 'binary' });
       expect(schema.properties.thumbnail).toEqual({ type: 'string', format: 'binary' });
@@ -3660,5 +3683,77 @@ describe('generator', () => {
       expect(schema.required).toContain('requiredFile');
       expect(schema.required).not.toContain('optionalName');
     });
+  });
+
+  test('with partial openapi meta (only summary/description, no method/path)', () => {
+    const appRouter = t.router({
+      admin: t.router({
+        getUsers: t.procedure
+          .meta({
+            openapi: {
+              summary: 'Get all users',
+              description: 'Returns a list of all registered users.',
+            } as any,
+          })
+          .input(z.object({ limit: z.string().optional() }))
+          .output(z.object({ users: z.array(z.string()) }))
+          .query(() => ({ users: ['alice', 'bob'] })),
+        createUser: t.procedure
+          .meta({
+            openapi: {
+              summary: 'Create a user',
+              description: 'Creates a new user with the given name.',
+            } as any,
+          })
+          .input(z.object({ name: z.string() }))
+          .output(z.object({ id: z.string() }))
+          .mutation(() => ({ id: '1' })),
+      }),
+    });
+
+    const document = generateOpenApiDocument(appRouter, defaultDocOpts);
+
+    // Should auto-generate path and method from procedure type
+    const getEndpoint = document.paths!['/admin.getUsers']?.get;
+    expect(getEndpoint).toBeDefined();
+    expect(getEndpoint?.summary).toBe('Get all users');
+    expect(getEndpoint?.description).toBe('Returns a list of all registered users.');
+
+    const postEndpoint = document.paths!['/admin.createUser']?.post;
+    expect(postEndpoint).toBeDefined();
+    expect(postEndpoint?.summary).toBe('Create a user');
+    expect(postEndpoint?.description).toBe('Creates a new user with the given name.');
+  });
+
+  test('with partial openapi meta mixed with procedures without meta', () => {
+    const appRouter = t.router({
+      items: t.router({
+        list: t.procedure
+          .meta({
+            openapi: {
+              summary: 'List items',
+            } as any,
+          })
+          .input(z.void())
+          .output(z.object({ items: z.array(z.string()) }))
+          .query(() => ({ items: [] })),
+        create: t.procedure
+          .input(z.object({ name: z.string() }))
+          .output(z.object({ id: z.string() }))
+          .mutation(() => ({ id: '1' })),
+      }),
+    });
+
+    const document = generateOpenApiDocument(appRouter, defaultDocOpts);
+
+    // Endpoint with partial meta should have summary and auto-generated path/method
+    const listEndpoint = document.paths!['/items.list']?.get;
+    expect(listEndpoint).toBeDefined();
+    expect(listEndpoint?.summary).toBe('List items');
+
+    // Endpoint without meta should still work with auto-generated defaults
+    const createEndpoint = document.paths!['/items.create']?.post;
+    expect(createEndpoint).toBeDefined();
+    expect(createEndpoint?.summary).toBeUndefined();
   });
 });

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -3693,7 +3693,7 @@ describe('generator', () => {
             openapi: {
               summary: 'Get all users',
               description: 'Returns a list of all registered users.',
-            } as any,
+            },
           })
           .input(z.object({ limit: z.string().optional() }))
           .output(z.object({ users: z.array(z.string()) }))
@@ -3703,7 +3703,7 @@ describe('generator', () => {
             openapi: {
               summary: 'Create a user',
               description: 'Creates a new user with the given name.',
-            } as any,
+            },
           })
           .input(z.object({ name: z.string() }))
           .output(z.object({ id: z.string() }))
@@ -3732,7 +3732,7 @@ describe('generator', () => {
           .meta({
             openapi: {
               summary: 'List items',
-            } as any,
+            },
           })
           .input(z.void())
           .output(z.object({ items: z.array(z.string()) }))


### PR DESCRIPTION
## Summary

- Fix callback spread order in `forEachOpenApiProcedure` from `{ openapi, ...meta }` to `{ ...meta, openapi }` so the merged openapi (with auto-generated defaults) isn't overwritten by the original partial meta
- Change the no-flags merge from `{ ...user, ...defaults }` to `{ ...defaults, ...user }` so user-provided values take priority (consistent with `additional` flag behavior)
- Add tests for partial openapi meta (only summary/description without method/path)

This enables providing just `summary` and `description` in the openapi meta while letting `method`, `path`, and `tags` be auto-generated from defaults:

```typescript
.meta({
  openapi: {
    summary: "Create an application",
    description: "Creates a new application in the specified project.",
  } as any,
})
```